### PR TITLE
Use circle/golang:1.12-node Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   lint:
     docker:
-      - image: hafizalfaza/node-go-sqip
+      - image: circleci/golang:1.12-node
     steps:
       - run: node --version
       - run: npm --version
@@ -28,7 +28,7 @@ jobs:
       - run: yarn run lint
   test-unit:
     docker:
-      - image: hafizalfaza/node-go-sqip
+      - image: circleci/golang:1.12-node
     steps:
       - run: node --version
       - run: npm --version
@@ -56,7 +56,7 @@ jobs:
       - run: yarn codecov
   test-e2e:
     docker:
-      - image: hafizalfaza/node-go-sqip
+      - image: circleci/golang:1.12-node
     steps:
       - run: node --version
       - run: npm --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM circleci/node:8
-RUN sudo wget https://dl.google.com/go/go1.12.linux-amd64.tar.gz
-RUN sudo tar -xvf go1.12.linux-amd64.tar.gz
-RUN sudo mv go /usr/local
-ENV GOROOT=/usr/local/go
-ENV PATH=$GOROOT/bin:$PATH
-RUN go version
-RUN node -v


### PR DESCRIPTION
When starting developing on this project I was quite confused to use an arbitrary image version from DockerHub, while a Dockerfile was available in the repo.
Turns out the CI does not build the image but uses a prebuilt published version.

All the image has is a Node installation plus Golang. The same is available as a [CircleCI convenience image](https://circleci.com/docs/2.0/circleci-images/).

The only "downside" is that they use the current Node LTS versions ([by now Node 10](https://circleci.com/blog/nodejs10-lts/)). I don't think this should be an issue as Node 8 is in maintenance already and [will go EOL end of year](https://github.com/nodejs/Release).

_Unproven assumption:_ it might even speed up CI runs as the Circle images are more likely to be available on the executor machine.