### PR TITLE
Document bootstraping a new plugin with --es-module flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,10 +84,8 @@ npm run build:watch
 
 To build a new SQIP plugin is pretty simple:
 
-1. Create a rough file structure via `lerna create sqip-plugin-my-amazing-plugin`
-2. Rename `lib` directory to `src`
-3. Change `package.json`: Replace main script path `lib` with `dist`
-4. Use the following template to rocket-start your new plugin:
+1. Create a rough file structure via `lerna create --es-module sqip-plugin-my-amazing-plugin`
+2. Use the following template to rocket-start your new plugin:
 
 ```js
 import { SqipPlugin } from 'sqip'


### PR DESCRIPTION
When creating a new plugin as described in `CONTRIBUTING.md`, the manual renaming step can be omitted when using the `--es-module` flag as described in [`@lerna/create`](https://github.com/lerna/lerna/tree/master/commands/create)

Code reference in lerna repo: 

- [Replace main script path `lib` with `dist`](https://github.com/lerna/lerna/blob/457d1e8a62f5caf0679973ae8bad564d7752ffd2/commands/create/index.js#L66)
- [Rename `lib` directory to `src`](https://github.com/lerna/lerna/blob/457d1e8a62f5caf0679973ae8bad564d7752ffd2/commands/create/index.js#L72)