### PR TITLE
feat(demo): add custom LQIP implementation which may beat current SQIP

### DIFF
--- a/demo/scripts/config.js
+++ b/demo/scripts/config.js
@@ -38,8 +38,12 @@ const variants = [
     task: async ({ path, dist }) => {
       const rawThumbnail = await sharp(path)
         .resize(300)
+        .jpeg()
         .toBuffer()
-      const tmpPath = resolve(tmpdir(), `sqip-demo-tmp-${Date.now()}.jpg`)
+      const tmpPath = resolve(
+        tmpdir(),
+        `sqip-demo-tmp-thumbnail-${Date.now()}.jpg`
+      )
       await writeFile(tmpPath, rawThumbnail)
       await execa(mozjpeg, ['-outfile', dist, tmpPath])
       await unlink(tmpPath)
@@ -60,6 +64,30 @@ const variants = [
       const result = await lqip.base64(path)
       await writeImage({ dataURI: result, dist })
       return result
+    }
+  },
+  {
+    name: 'lqip-custom',
+    title: 'LQIP custom',
+    description: html`
+      <p>
+        32px thumbnail generated with <a href="https://sharp.dimens.io/en/stable/">sharp</a>,
+        minified with
+        <a href="https://github.com/mozilla/mozjpeg">mozjpeg</a>
+      </p>
+    `,
+    resultFileType: 'jpg',
+    task: async ({ path, dist }) => {
+      const rawThumbnail = await sharp(path)
+        .resize(32)
+        .jpeg()
+        .toBuffer()
+      const tmpPath = resolve(tmpdir(), `sqip-demo-tmp-lqip-${Date.now()}.jpg`)
+      await writeFile(tmpPath, rawThumbnail)
+      await execa(mozjpeg, ['-outfile', dist, tmpPath])
+      await unlink(tmpPath)
+      const optimizedThumbnail = await readFile(dist)
+      return optimizedThumbnail.toString()
     }
   },
   {

--- a/demo/scripts/generate-html.js
+++ b/demo/scripts/generate-html.js
@@ -35,7 +35,14 @@ function VariantResult({
           `
         : html`
             <div class="preview-wrapper" style="${wrapperStyle}">
-              <img class="preview" alt="${name}" src="${url}" height="auto" />
+              <img
+                class="${['preview', variantName.indexOf('lqip') !== -1 && 'lqip']
+                  .filter(Boolean)
+                  .join(' ')}"
+                alt="${name}"
+                src="${url}"
+                height="auto"
+              />
             </div>
           `}
       <div class="sizes">
@@ -149,6 +156,10 @@ const Row = ({ image }) => {
             img.preview {
               display: block;
               width: 100%;
+            }
+            img.preview.lqip {
+              filter: blur(12px);
+              transform: scale(1.15);
             }
             table {
               border-collapse: collapse;


### PR DESCRIPTION
Seems like sharp + mozjpeg is more efficient as [lqip](https://github.com/zouhir/lqip)

This adds a new LQIP option, with 32px size. Sometimes even smaller as SQIP, and incredibly detailed 😱

Additionally: 

Adds css blur to LQIP previews to make comparison more fair. Note: Needs scaling, otherwise has ugly border.


![Screenshot 2019-06-17 at 16 56 02](https://user-images.githubusercontent.com/1737026/59614439-0ed06f00-9121-11e9-8a85-c0db7e64bfdb.png)
