### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Multiple input images will result in an array of result objects.
 #### Process folder with default settings
 
 ```js
-import sqip from 'sqip' // in node will be => const { default: sqip } = require('sqip');
+import sqip from 'sqip' // in node will be => const sqip = require('sqip').default
 import { resolve } from 'path'
 
 ;(async () => {

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Multiple input images will result in an array of result objects.
 #### Process folder with default settings
 
 ```js
-import sqip from 'sqip'
+import sqip from 'sqip' // in node will be => const { default: sqip } = require('sqip');
 import { resolve } from 'path'
 
 ;(async () => {


### PR DESCRIPTION
It is a little bit tricky the use of the library in node because you have to include as destructure in order to get a meanful name since it is exported as default:

const  { default: sqip } = require('sqip')
