### PR TITLE
fix(squip-plugin-pixels): fix colormaping since sharp converts to srgb

### DIFF
--- a/packages/sqip-plugin-pixels/__tests__/unit/sqip-plugin-pixels.test.js
+++ b/packages/sqip-plugin-pixels/__tests__/unit/sqip-plugin-pixels.test.js
@@ -24,7 +24,7 @@ describe('sqip-plugin-pixels', () => {
     // Should be one svg with 8 * 5 pixel rects
     expect($('svg')).toHaveLength(1)
     const $rects = $('svg > rect')
-    expect($rects).toHaveLength(8 * 5)
+    expect($rects).toHaveLength(6 * 5)
     const firstRect = $('svg > rect').get(0)
     expect(firstRect.attribs.width).toEqual('100')
   })
@@ -40,7 +40,7 @@ describe('sqip-plugin-pixels', () => {
     // Should be one svg with 16 * 10 pixel rects with 50px size
     expect($('svg')).toHaveLength(1)
     const $rects = $('svg > rect')
-    expect($rects).toHaveLength(16 * 10)
+    expect($rects).toHaveLength(12 * 10)
     const firstRect = $('svg > rect').get(0)
     expect(firstRect.attribs.width).toEqual('50')
   })

--- a/packages/sqip-plugin-pixels/src/sqip-plugin-pixels.js
+++ b/packages/sqip-plugin-pixels/src/sqip-plugin-pixels.js
@@ -46,7 +46,7 @@ export default class PixelsPlugin extends SqipPlugin {
     let row = 0
 
     const canvas = SVG().size(info.width * pixelSize, info.height * pixelSize)
-    for (var i = 0; i < data.length; i += 3) {
+    for (var i = 0; i < data.length; i += 4) {
       var red = data[i]
       var green = data[i + 1]
       var blue = data[i + 2]


### PR DESCRIPTION
The new versions of sharp converts to `sRGB`, looping for pixels color lands on alpha channel values and this leads to incorrect colors since the looping is for 3 channels.

A better solution would be to use sharp `.toColorspace('rgb')` [sharp/docs/toColorspace](https://sharp.pixelplumbing.com/api-colour#tocolourspace)

But for now it throws and error if no colour profile is provided [sharp/issues/1323](https://github.com/lovell/sharp/issues/1323)

Let me know if there is something I'm missing or should change.

Thank you!